### PR TITLE
Add skeleton version in install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Informations:
 
 ## Quickstart Installation (docker)
 
-1. Run `composer create-project pocky/modern-plugin-skeleton ProjectName` or clone this project
+1. Run `composer create-project pocky/modern-plugin-skeleton ProjectName dev-main` or clone this project
 
 2. From the plugin skeleton root directory, run the following commands:
 


### PR DESCRIPTION
When I try the command described in the README, I got this error:

```
$ composer create-project pocky/modern-plugin-skeleton SyliusMyFirstPlugin 
Creating a "pocky/modern-plugin-skeleton" project at "./SyliusMyFirstPlugin"

                                                                              
  [InvalidArgumentException]                                                  
  Could not find package pocky/modern-plugin-skeleton with stability stable.  
                                                                              

create-project [-s|--stability STABILITY] [--prefer-source] [--prefer-dist] [--prefer-install PREFER-INSTALL] [--repository REPOSITORY] [--repository-url REPOSITORY-URL] [--add-repository] [--dev] [--no-dev] [--no-custom-installers] [--no-scripts] [--no-progress] [--no-secure-http] [--keep-vcs] [--remove-vcs] [--no-install] [--ignore-platform-req IGNORE-PLATFORM-REQ] [--ignore-platform-reqs] [--ask] [--] [<package>] [<directory>] [<version>]

```

This pull request adds the dev version `dev-main` at the command to fix this issue.