### PR TITLE
Bump docker php version to 8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-fpm-alpine
+FROM php:8.0-fpm-alpine
 
 # Install composer
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer


### PR DESCRIPTION
Change default php version from 7.4 to 8.0 to avoid package errors

```
Your lock file does not contain a compatible set of packages. Please run composer update.

  Problem 1
    - fig/link-util is locked to version 1.2.0 and an update of this package was not requested.
    - fig/link-util 1.2.0 requires php >=8.0.0 -> your php version (7.4.29) does not satisfy that requirement.
  Problem 2
    - lcobucci/clock is locked to version 2.2.0 and an update of this package was not requested.
    - lcobucci/clock 2.2.0 requires php ^8.0 -> your php version (7.4.29) does not satisfy that requirement.
  Problem 3
    - psr/cache is locked to version 2.0.0 and an update of this package was not requested.
    - psr/cache 2.0.0 requires php >=8.0.0 -> your php version (7.4.29) does not satisfy that requirement.
  Problem 4
    - psr/link is locked to version 2.0.1 and an update of this package was not requested.
    - psr/link 2.0.1 requires php >=8.0.0 -> your php version (7.4.29) does not satisfy that requirement.
  Problem 5
    - psr/log is locked to version 2.0.0 and an update of this package was not requested.
    - psr/log 2.0.0 requires php >=8.0.0 -> your php version (7.4.29) does not satisfy that requirement.
  Problem 6
    - sylius-labs/polyfill-symfony-event-dispatcher is locked to version v1.1.0 and an update of this package was not requested.
    - sylius-labs/polyfill-symfony-event-dispatcher v1.1.0 requires php ^8.0 -> your php version (7.4.29) does not satisfy that requirement.
  Problem 7
    - sylius/calendar is locked to version v0.3.0 and an update of this package was not requested.
    - sylius/calendar v0.3.0 requires php ^8.0 -> your php version (7.4.29) does not satisfy that requirement.
  Problem 8
    - sylius/grid-bundle is locked to version v1.11.0 and an update of this package was not requested.
    - sylius/grid-bundle v1.11.0 requires php ^8.0 -> your php version (7.4.29) does not satisfy that requirement.
  Problem 9
    - sylius/mailer-bundle is locked to version v1.7.1 and an update of this package was not requested.
    - sylius/mailer-bundle v1.7.1 requires php ^8.0 -> your php version (7.4.29) does not satisfy that requirement.
  Problem 10
    - sylius/sylius is locked to version v1.11.5 and an update of this package was not requested.
    - sylius/sylius v1.11.5 requires php ^8.0 -> your php version (7.4.29) does not satisfy that requirement.
  Problem 11
    - symfony/event-dispatcher-contracts is locked to version v3.0.1 and an update of this package was not requested.
    - symfony/event-dispatcher-contracts v3.0.1 requires php >=8.0.2 -> your php version (7.4.29) does not satisfy that requirement.
  Problem 12
    - symfony/mime is locked to version v6.0.9 and an update of this package was not requested.
    - symfony/mime v6.0.9 requires php >=8.0.2 -> your php version (7.4.29) does not satisfy that requirement.
  Problem 13
    - symfony/web-link is locked to version v6.0.3 and an update of this package was not requested.
    - symfony/web-link v6.0.3 requires php >=8.0.2 -> your php version (7.4.29) does not satisfy that requirement.
  Problem 14
    - sylius-labs/coding-standard is locked to version v4.2.0 and an update of this package was not requested.
    - sylius-labs/coding-standard v4.2.0 requires php ^8.0 -> your php version (7.4.29) does not satisfy that requirement.
  Problem 15
    - symfony/css-selector is locked to version v6.0.3 and an update of this package was not requested.
    - symfony/css-selector v6.0.3 requires php >=8.0.2 -> your php version (7.4.29) does not satisfy that requirement.
  Problem 16
    - symfony/dom-crawler is locked to version v6.0.9 and an update of this package was not requested.
    - symfony/dom-crawler v6.0.9 requires php >=8.0.2 -> your php version (7.4.29) does not satisfy that requirement.
  Problem 17
    - fig/link-util 1.2.0 requires php >=8.0.0 -> your php version (7.4.29) does not satisfy that requirement.
    - api-platform/core v2.6.8 requires fig/link-util ^1.0 -> satisfiable by fig/link-util[1.2.0].
    - api-platform/core is locked to version v2.6.8 and an update of this package was not requested.
```